### PR TITLE
remove outdated reference to c4l13, link to wiki instead

### DIFF
--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -37,7 +37,7 @@ attention.
     actively harassing you, then you will need a third party to step in.
 
     If you are at a conference or other event, find the event organizer or
-    staff person, who should be listed [on the wiki](https://github.com/code4lib/antiharassment-policy).
+    staff person, who should be listed [on the wiki](http://wiki.code4lib.org/index.php/Main_Page).
     If you can't find the event organizer, there will be other staff 
     available to help if the situation calls for immediate action.
 


### PR DESCRIPTION
Probably unwise to leave in a reference to a specific conference that'll need to be updated each year. I pointed people towards the wiki, where conference staff are usually listed in a pretty easy-to-find location.
