### PR TITLE
Correct a typo in the 2019 conference transparency report

### DIFF
--- a/transparency_reports/2019_national_conference_annual_report.md
+++ b/transparency_reports/2019_national_conference_annual_report.md
@@ -32,7 +32,7 @@ incidents, and come to consensus on responses.
    disturbed by the all-gender restroom signage, and suggested they seek out a
    gender-specific restroom.
 3. Comments made publicly about one of the conference speakers on Slack and
-   Twitter become unwelcoming.
+   Twitter became unwelcoming.
 4. A report was taken regarding a microaggression experience by an attendee. An
    announcement was made from the podium the next morning reminding attendees to
    model desired behavior in the community. The statement was intended to

--- a/transparency_reports/2019_national_conference_annual_report.md
+++ b/transparency_reports/2019_national_conference_annual_report.md
@@ -33,7 +33,7 @@ incidents, and come to consensus on responses.
    gender-specific restroom.
 3. Comments made publicly about one of the conference speakers on Slack and
    Twitter became unwelcoming.
-4. A report was taken regarding a microaggression experience by an attendee. An
+4. A report was taken regarding a microaggression experienced by an attendee. An
    announcement was made from the podium the next morning reminding attendees to
    model desired behavior in the community. The statement was intended to
    address this report as well as the incident described in #3.


### PR DESCRIPTION
@aslaughter cringed.